### PR TITLE
[Proposal] Adding download badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Open Source and free alternative to Antidote dictionary.
 
 [Data credits](https://docs.remede.camarm.fr/docs/database/credits) • [License](https://github.com/camarm-dev/remede/blob/main/LICENSE) • [Website](https://remede.camarm.fr) • **[Download](https://remede.camarm.fr/download)** • **[API](https://api-remede.camarm.fr/docs)**
 
+[<img src="https://raw.githubusercontent.com/deckerst/common/main/assets/get-it-on-github.png"
+      alt='Get it on GitHub'
+      height="80">](https://github.com/camarm-dev/remede/releases/latest)
+[<img src="https://github.com/user-attachments/assets/713d71c5-3dec-4ec4-a3f2-8d28d025a9c6"
+      alt='Get it on Obtainium'
+      height="80">](https://apps.obtainium.imranr.dev/redirect?r=obtainium://app/%7B%22id%22%3A%22dev.camarm.remede%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fcamarm-dev%2Fremede%22%2C%22author%22%3A%22camarm-dev%22%2C%22name%22%3A%22Rem%C3%A8de%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Afalse%2C%5C%22fallbackToOlderReleases%5C%22%3Atrue%2C%5C%22filterReleaseTitlesByRegEx%5C%22%3A%5C%22%5C%22%2C%5C%22filterReleaseNotesByRegEx%5C%22%3A%5C%22%5C%22%2C%5C%22verifyLatestTag%5C%22%3Afalse%2C%5C%22dontSortReleasesList%5C%22%3Afalse%2C%5C%22useLatestAssetDateAsReleaseDate%5C%22%3Afalse%2C%5C%22releaseTitleAsVersion%5C%22%3Afalse%2C%5C%22trackOnly%5C%22%3Afalse%2C%5C%22versionExtractionRegEx%5C%22%3A%5C%22%5C%22%2C%5C%22matchGroupToUse%5C%22%3A%5C%22%5C%22%2C%5C%22versionDetection%5C%22%3Atrue%2C%5C%22releaseDateAsVersion%5C%22%3Afalse%2C%5C%22useVersionCodeAsOSVersion%5C%22%3Afalse%2C%5C%22apkFilterRegEx%5C%22%3A%5C%22%5C%22%2C%5C%22invertAPKFilter%5C%22%3Afalse%2C%5C%22autoApkFilterByArch%5C%22%3Atrue%2C%5C%22appName%5C%22%3A%5C%22%5C%22%2C%5C%22shizukuPretendToBeGooglePlay%5C%22%3Afalse%2C%5C%22allowInsecure%5C%22%3Afalse%2C%5C%22exemptFromBackgroundUpdates%5C%22%3Afalse%2C%5C%22skipUpdateNotifications%5C%22%3Afalse%2C%5C%22about%5C%22%3A%5C%22%5C%22%2C%5C%22refreshBeforeDownload%5C%22%3Afalse%7D%22%2C%22overrideSource%22%3A%22GitHub%22%7D
+)
+
 </div>
 
 ## Breaking changes with Remède 1.4.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open Source and free alternative to Antidote dictionary.
 
 [<kbd>Open application</kbd>](https://remede-app.camarm.fr)
 
-[Data credits](https://docs.remede.camarm.fr/docs/database/credits) • [License](https://github.com/camarm-dev/remede/blob/main/LICENSE) • [Website](https://remede.camarm.fr) • **[Download](https://remede.camarm.fr/download)** • **[API](https://api-remede.camarm.fr/docs)**
+[Data credits](https://docs.remede.camarm.fr/docs/database/credits) • [License](https://github.com/camarm-dev/remede/blob/main/LICENSE) • [Website](https://remede.camarm.fr) • **[API](https://api-remede.camarm.fr/docs)**
 
 [<img src="https://raw.githubusercontent.com/deckerst/common/main/assets/get-it-on-github.png"
       alt='Get it on GitHub'


### PR DESCRIPTION
## What is this PR for ?

Simple proposal for adding a download badge on the readme.
* In order to make it easier for users to obtain the application, _and it looks nice :)_
   - Added the link to the github download page.
   - Added the link for adding it to the application managed by [Obtainium ](https://github.com/ImranR98/Obtainium)_(link including the configuration)_
  - Removal of the "Download" which has become useless

**It looks like that, with badges:**
<img width="960" alt="vivaldi_daqx9Puoeh" src="https://github.com/user-attachments/assets/c433bf12-3a59-4fd1-a671-e3c621cb402c" />

I am at your disposal if necessary, if you do not like it, do not hesitate to refuse this proposal.
